### PR TITLE
Feat/cafe list

### DIFF
--- a/src/main/java/com/example/demo/cafe/implement/CafeReader.java
+++ b/src/main/java/com/example/demo/cafe/implement/CafeReader.java
@@ -6,8 +6,11 @@ import org.springframework.stereotype.Component;
 
 import com.example.demo.cafe.domain.Cafe;
 import com.example.demo.cafe.infrastructure.CafeEntity;
+import com.example.demo.cafe.infrastructure.CafeQueryRepository;
 import com.example.demo.cafe.infrastructure.CafeRepository;
+import com.example.demo.cafe.presentation.CafeSearchListRequest;
 import com.example.demo.exception.CafegoryException;
+import com.example.demo.trash.dto.SliceResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 public class CafeReader {
 
 	private final CafeRepository cafeRepository;
+	private final CafeQueryRepository cafeQueryRepository;
 
 	public Cafe read(Long cafeId) {
 		CafeEntity cafeEntity = cafeRepository.findById(cafeId)
@@ -29,5 +33,9 @@ public class CafeReader {
 			.orElseThrow(() -> new CafegoryException(CAFE_NOT_FOUND));
 
 		return cafeEntity.toCafeWithTagsAndMenu();
+	}
+
+	public SliceResponse<CafeEntity> readCafes(CafeSearchListRequest request) {
+		return cafeQueryRepository.findCafeByRegionAndKeyword(request);
 	}
 }

--- a/src/main/java/com/example/demo/cafe/infrastructure/CafeEntity.java
+++ b/src/main/java/com/example/demo/cafe/infrastructure/CafeEntity.java
@@ -16,6 +16,7 @@ import org.hibernate.annotations.Where;
 
 import com.example.demo.cafe.domain.Address;
 import com.example.demo.cafe.domain.Cafe;
+import com.example.demo.study.infrastructure.CafeStudyEntity;
 import com.example.demo.trash.implement.BaseEntity;
 
 import lombok.AccessLevel;
@@ -52,6 +53,9 @@ public class CafeEntity extends BaseEntity {
 
 	@OneToMany(mappedBy = "cafe")
 	private List<MenuEntity> menus = new ArrayList<>();
+
+	@OneToMany(mappedBy = "cafe")
+	private List<CafeStudyEntity> cafeStudies = new ArrayList<>();
 
 	@Builder
 	private CafeEntity(String name, String mainImageUrl, AddressEmbeddable address, String sns) {

--- a/src/main/java/com/example/demo/cafe/infrastructure/CafeQueryRepository.java
+++ b/src/main/java/com/example/demo/cafe/infrastructure/CafeQueryRepository.java
@@ -1,0 +1,180 @@
+package com.example.demo.cafe.infrastructure;
+
+import static com.example.demo.cafe.infrastructure.QBusinessHourEntity.*;
+import static com.example.demo.cafe.infrastructure.QCafeEntity.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.example.demo.cafe.domain.CafeTagType;
+import com.example.demo.cafe.presentation.CafeSearchListRequest;
+import com.example.demo.exception.CafegoryException;
+import com.example.demo.exception.ExceptionType;
+import com.example.demo.trash.dto.SliceResponse;
+import com.example.demo.util.PagingUtil;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CafeQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public SliceResponse<CafeEntity> findCafeByRegionAndKeyword(CafeSearchListRequest request) {
+		Pageable pageable = PagingUtil.of(request.getPage(), request.getSizePerPage());
+
+		JPAQuery<Long> cafeIds = queryFactory
+			.select(businessHourEntity.cafe.id).distinct()
+			.from(businessHourEntity)
+			.join(businessHourEntity.cafe, cafeEntity)
+			.where(
+				businessHourContains(request.getOpeningDateTime(), request.getClosingDateTime()),
+				keywordContains(request.getKeyword())
+					.or(cafeNameContains(request.getKeyword())),
+				hasAllCafeTagTypes(request.getCafeTagTypes())
+			)
+			.orderBy(cafeEntity.cafeStudies.size().asc());
+
+		JPAQuery<CafeEntity> query = queryFactory
+			.select(cafeEntity)
+			.from(cafeEntity)
+			.where(cafeEntity.id.in(cafeIds));
+
+		return SliceResponse.of(PagingUtil.toSlice(query, pageable));
+	}
+
+	private BooleanExpression keywordContains(String keyword) {
+		// 만약 이 메서드가 동작하지 않는다면 DB의 맞는 Expressions.stringTemplate 의 내부 구문을 바꿔야 한다.
+		// DB에 등록된 키워드와 파라미터의 키워드 둘다 공백제거 한뒤 비교한다.
+		return keyword == null ? null :
+			Expressions.stringTemplate("function('replace', {0}, ' ', '')", cafeEntity.cafeKeywords.any().keyword)
+				.likeIgnoreCase("%" + keyword.replace(" ", "") + "%");
+	}
+
+	private BooleanExpression cafeNameContains(String cafeName) {
+		// 만약 이 메서드가 동작하지 않는다면 DB의 맞는 Expressions.stringTemplate 의 내부 구문을 바꿔야 한다.
+		// DB에 등록된 키워드와 파라미터의 키워드 둘다 공백제거 한뒤 비교한다.
+		return cafeName == null ? null :
+			Expressions.stringTemplate("function('replace', {0}, ' ', '')", cafeEntity.name)
+				.likeIgnoreCase("%" + cafeName.replace(" ", "") + "%");
+	}
+
+	private BooleanExpression businessHourContains(LocalDateTime openingDateTime, LocalDateTime closingDateTime) {
+		boolean isStartDateAndEndDateEquals = openingDateTime.getDayOfWeek().equals(closingDateTime.getDayOfWeek());
+
+		// 시간 유효성 검사
+		if (openingDateTime.isAfter(closingDateTime) || openingDateTime.isEqual(closingDateTime)) {
+			throw new CafegoryException(ExceptionType.CAFE_SEARCH_INVALID_TIME_RANGE);
+		}
+
+		// 시작시간과 종료시간이 같은 날인 경우
+		if (isStartDateAndEndDateEquals) {
+			return businessHourEntity.dayOfWeek.eq(openingDateTime.getDayOfWeek())
+				.and(businessHourEntity.openingTime.loe(closingDateTime.toLocalTime())
+					.and(businessHourEntity.closingTime.goe(openingDateTime.toLocalTime())));
+		}
+
+		// 시작시간과 종료시간이 다른 날인 경우
+		return businessHourEntity.dayOfWeek.eq(closingDateTime.getDayOfWeek())
+			.and(businessHourEntity.openingTime.loe(closingDateTime.toLocalTime()))
+			.or((businessHourEntity.dayOfWeek.eq(openingDateTime.getDayOfWeek()))
+				.and(businessHourEntity.closingTime.goe(openingDateTime.toLocalTime())));
+	}
+
+	private BooleanExpression hasAllCafeTagTypes(List<CafeTagType> cafeTagTypes) {
+		if (cafeTagTypes == null || cafeTagTypes.isEmpty())
+			return null;
+
+		return cafeTagTypes.stream()
+			.map(type -> cafeEntity.cafeCafeTags.any().cafeTag.type.eq(type))
+			.reduce(BooleanExpression::and)
+			.orElse(null);
+	}
+
+	// public List<Cafe> findWithDynamicFilterAndNoPaging(CafeSearchCondition searchCondition) {
+	// 	return queryFactory
+	// 		.selectFrom(cafe)
+	// 		.where(
+	// 			isAbleToStudy(searchCondition.isAbleToStudy()),
+	// 			regionContains(searchCondition.getRegion()),
+	// 			maxAllowableStayInLoe(searchCondition.getMaxAllowableStay()),
+	// 			minBeveragePriceLoe(searchCondition.getMinMenuPrice()),
+	// 			businessHourBetween(searchCondition.getStartTime(), searchCondition.getEndTime(),
+	// 				searchCondition.getNow())
+	// 		)
+	// 		.fetch();
+	// }
+	//
+	// public Page<Cafe> findWithDynamicFilter(CafeSearchCondition searchCondition, Pageable pageable) {
+	// 	List<Cafe> content = queryFactory
+	// 		.selectFrom(cafe)
+	// 		.where(
+	// 			isAbleToStudy(searchCondition.isAbleToStudy()),
+	// 			regionContains(searchCondition.getRegion()),
+	// 			maxAllowableStayInLoe(searchCondition.getMaxAllowableStay()),
+	// 			minBeveragePriceLoe(searchCondition.getMinMenuPrice()),
+	// 			businessHourBetween(searchCondition.getStartTime(), searchCondition.getEndTime(),
+	// 				searchCondition.getNow())
+	// 		)
+	// 		.offset(pageable.getOffset())
+	// 		.limit(pageable.getPageSize())
+	// 		.fetch();
+	//
+	// 	JPAQuery<Long> countQuery = queryFactory
+	// 		.select(cafe.count())
+	// 		.from(cafe)
+	// 		.where(
+	// 			isAbleToStudy(searchCondition.isAbleToStudy()),
+	// 			regionContains(searchCondition.getRegion()),
+	// 			maxAllowableStayInLoe(searchCondition.getMaxAllowableStay()),
+	// 			minBeveragePriceLoe(searchCondition.getMinMenuPrice()),
+	// 			businessHourBetween(searchCondition.getStartTime(), searchCondition.getEndTime(),
+	// 				searchCondition.getNow())
+	// 		);
+	// 	return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	// }
+	//
+	// private BooleanExpression businessHourBetween(LocalTime filteringStartTime, LocalTime filteringEndTime,
+	// 	LocalDateTime now) {
+	// 	if (filteringStartTime == null || filteringEndTime == null || now == null) {
+	// 		return null;
+	// 	}
+	// 	String nowDayOfWeek = now.getDayOfWeek().toString();
+	// 	return cafe.id.in(
+	// 		JPAExpressions
+	// 			.select(businessHour.cafe.id)
+	// 			.from(businessHour)
+	// 			.where(
+	// 				businessHour.day.eq(nowDayOfWeek),
+	// 				businessHour.startTime.eq(filteringStartTime).or(businessHour.startTime.after(filteringStartTime)),
+	// 				businessHour.endTime.eq(filteringEndTime).or(businessHour.endTime.before(filteringEndTime))
+	// 			)
+	// 	);
+	// }
+	//
+	// private BooleanExpression minBeveragePriceLoe(MinMenuPrice minMenuPrice) {
+	// 	return minMenuPrice == null ? null : cafe.minBeveragePrice.loe(minMenuPrice.getRealValue());
+	// }
+	//
+	// //매개변수인 MaxAllowableStay보다 작거나 같은 MaxAllowableStay의 Enum상수가 in절안에 List로 들어감
+	// private BooleanExpression maxAllowableStayInLoe(MaxAllowableStay maxTime) {
+	// 	return maxTime == null
+	// 		? null : cafe.maxAllowableStay.in(MaxAllowableStay.findLoe(maxTime));
+	// }
+	//
+	// private BooleanExpression regionContains(String region) {
+	// 	return isBlank(region) ? null : cafe.address.region.contains(region);
+	// }
+	//
+	// private BooleanExpression isAbleToStudy(boolean isAbleToStudy) {
+	// 	return cafe.isAbleToStudy.eq(isAbleToStudy);
+	// }
+}

--- a/src/main/java/com/example/demo/cafe/presentation/CafeController.java
+++ b/src/main/java/com/example/demo/cafe/presentation/CafeController.java
@@ -1,16 +1,18 @@
 package com.example.demo.cafe.presentation;
 
-import com.example.demo.cafe.domain.BusinessHour;
-import com.example.demo.cafe.domain.Cafe;
-import com.example.demo.cafe.service.BusinessHourService;
-import com.example.demo.cafe.service.CafeDetailResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.demo.cafe.domain.BusinessHour;
+import com.example.demo.cafe.domain.Cafe;
+import com.example.demo.cafe.service.BusinessHourService;
 import com.example.demo.cafe.service.CafeQueryService;
+import com.example.demo.trash.dto.SliceResponse;
 import com.example.demo.util.TimeUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,14 @@ public class CafeController {
 		boolean isOpen = businessHourService.isOpen(businessHour, timeUtil.now());
 
 		CafeDetailResponse response = CafeDetailResponse.of(cafe, businessHour, isOpen);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping
+	public ResponseEntity<SliceResponse<CafeSearchListResponse>> getCafes(
+		@Validated @ModelAttribute CafeSearchListRequest request
+	) {
+		SliceResponse<CafeSearchListResponse> response = cafeQueryService.searchCafesByDynamicFilter(request);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/example/demo/cafe/presentation/CafeDetailResponse.java
+++ b/src/main/java/com/example/demo/cafe/presentation/CafeDetailResponse.java
@@ -1,4 +1,4 @@
-package com.example.demo.cafe.service;
+package com.example.demo.cafe.presentation;
 
 import java.time.LocalTime;
 import java.util.ArrayList;

--- a/src/main/java/com/example/demo/cafe/presentation/CafeSearchListRequest.java
+++ b/src/main/java/com/example/demo/cafe/presentation/CafeSearchListRequest.java
@@ -1,0 +1,53 @@
+package com.example.demo.cafe.presentation;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.example.demo.cafe.domain.CafeTagType;
+import com.example.demo.trash.dto.PagedRequest;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CafeSearchListRequest extends PagedRequest {
+
+	private String keyword;
+	@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime openingDateTime;
+	@DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+	private LocalDateTime closingDateTime;
+	@JsonProperty("cafeTags")
+	private List<CafeTagType> cafeTagTypes = new ArrayList<>();
+
+	protected CafeSearchListRequest() {
+		super();
+	}
+
+	@Builder
+	public CafeSearchListRequest(int page, int sizePerPage, String keyword, LocalDateTime openingDateTime,
+		LocalDateTime closingDateTime, List<CafeTagType> cafeTagTypes
+	) {
+		super(page, sizePerPage);
+		this.keyword = keyword;
+		this.openingDateTime = openingDateTime;
+		this.closingDateTime = closingDateTime;
+		this.cafeTagTypes = cafeTagTypes;
+	}
+
+	public void applyDefaultOpeningTime(LocalDateTime openingDateTime) {
+		if (this.openingDateTime == null) {
+			this.openingDateTime = openingDateTime;
+		}
+	}
+
+	public void applyDefaultClosingTime(LocalDateTime closingDateTime) {
+		if (this.closingDateTime == null) {
+			this.closingDateTime = closingDateTime;
+		}
+	}
+}

--- a/src/main/java/com/example/demo/cafe/presentation/CafeSearchListResponse.java
+++ b/src/main/java/com/example/demo/cafe/presentation/CafeSearchListResponse.java
@@ -1,0 +1,72 @@
+package com.example.demo.cafe.presentation;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.example.demo.cafe.domain.BusinessHour;
+import com.example.demo.cafe.domain.CafeTagType;
+import com.example.demo.cafe.infrastructure.CafeEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CafeSearchListResponse {
+
+	private CafeInfo cafeInfo;
+	private CafeBusinessHourInfo cafeBusinessInfo;
+
+	public static CafeSearchListResponse from(CafeEntity cafe, BusinessHour businessHour) {
+		CafeSearchListResponse response = new CafeSearchListResponse();
+		response.cafeInfo = createCafeInfo(cafe);
+		response.cafeBusinessInfo = createCafeBusinessInfo(businessHour);
+
+		return response;
+	}
+
+	private static CafeInfo createCafeInfo(CafeEntity cafe) {
+		return CafeInfo.builder()
+			.id(cafe.getId())
+			.imgUrl(cafe.getMainImageUrl())
+			.name(cafe.getName())
+			.tags(cafe.getCafeCafeTags().stream()
+				.map(tags -> tags.getCafeTag().getType())
+				.collect(Collectors.toList())
+			)
+			.build();
+	}
+
+	private static CafeBusinessHourInfo createCafeBusinessInfo(BusinessHour businessHour) {
+		return CafeBusinessHourInfo.builder()
+			.openingTime(businessHour.getOpeningTme())
+			.closingTime(businessHour.getClosingTme())
+			.build();
+	}
+
+	@Getter
+	@Setter
+	@Builder
+	private static class CafeInfo {
+
+		private Long id;
+		private String name;
+		private String imgUrl;
+		private List<CafeTagType> tags = new ArrayList<>();
+	}
+
+	@Getter
+	@Setter
+	@Builder
+	private static class CafeBusinessHourInfo {
+
+		private LocalTime openingTime;
+		private LocalTime closingTime;
+	}
+}

--- a/src/main/java/com/example/demo/cafe/service/CafeQueryService.java
+++ b/src/main/java/com/example/demo/cafe/service/CafeQueryService.java
@@ -1,10 +1,22 @@
 package com.example.demo.cafe.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.demo.cafe.domain.BusinessHour;
 import com.example.demo.cafe.domain.Cafe;
+import com.example.demo.cafe.implement.BusinessHourReader;
 import com.example.demo.cafe.implement.CafeReader;
+import com.example.demo.cafe.infrastructure.CafeEntity;
+import com.example.demo.cafe.presentation.CafeSearchListRequest;
+import com.example.demo.cafe.presentation.CafeSearchListResponse;
+import com.example.demo.trash.dto.SliceResponse;
+import com.example.demo.util.PagingUtil;
+import com.example.demo.util.TimeUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,17 +25,41 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class CafeQueryService {
 
-    private final CafeReader cafeReader;
+	private final CafeReader cafeReader;
+	private final BusinessHourReader businessHourReader;
 
-    public Cafe getCafe(Long cafeId) {
-        return cafeReader.getWithTags(cafeId);
-    }
+	private final TimeUtil timeUtil;
 
-    // private List<CafeStudyEntity> filterAndSortByIdDesc(List<CafeStudyEntity> cafeStudies,
-    // 	Predicate<CafeStudyEntity> predicate) {
-    // 	return cafeStudies.stream()
-    // 		.filter(predicate)
-    // 		.sorted(Comparator.comparing(CafeStudyEntity::getId).reversed())
-    // 		.collect(Collectors.toList());
-    // }
+	public Cafe getCafe(Long cafeId) {
+		return cafeReader.getWithTags(cafeId);
+	}
+
+	public SliceResponse<CafeSearchListResponse> searchCafesByDynamicFilter(CafeSearchListRequest request) {
+		Pageable pageable = PagingUtil.of(request.getPage(), request.getSizePerPage());
+
+		applyDefaultTimes(request);
+		SliceResponse<CafeEntity> cafeEntities = cafeReader.readCafes(request);
+
+		List<CafeSearchListResponse> cafeResponses = cafeEntities.getContent().stream()
+			.map(cafe -> {
+				BusinessHour businessHour = businessHourReader.readBy(cafe.getId(), timeUtil.now().getDayOfWeek());
+				return CafeSearchListResponse.from(cafe, businessHour);
+			})
+			.collect(Collectors.toList());
+
+		return SliceResponse.of(PagingUtil.toSlice(cafeResponses, pageable));
+	}
+
+	private void applyDefaultTimes(CafeSearchListRequest request) {
+		request.applyDefaultOpeningTime(timeUtil.minLocalDateTime(timeUtil.now()));
+		request.applyDefaultClosingTime(timeUtil.maxLocalDateTime(timeUtil.now()));
+	}
+
+	// private List<CafeStudyEntity> filterAndSortByIdDesc(List<CafeStudyEntity> cafeStudies,
+	// 	Predicate<CafeStudyEntity> predicate) {
+	// 	return cafeStudies.stream()
+	// 		.filter(predicate)
+	// 		.sorted(Comparator.comparing(CafeStudyEntity::getId).reversed())
+	// 		.collect(Collectors.toList());
+	// }
 }

--- a/src/main/java/com/example/demo/exception/ExceptionType.java
+++ b/src/main/java/com/example/demo/exception/ExceptionType.java
@@ -72,9 +72,11 @@ public enum ExceptionType {
 	REVIEW_INVALID_RATE_RANGE(BAD_REQUEST, "평점이 허용된 범위를 벗어났습니다."),
 
 	CAFE_NOT_FOUND(NOT_FOUND, "없는 카페입니다."),
+	CAFES_NOT_FOUND(NOT_FOUND, "일치하는 카페가 존재하지 않습니다."),
 	CAFE_BUSINESS_HOUR_NOT_FOUND(NOT_FOUND, "영업시간이 존재하지 않습니다."),
 	CAFE_INVALID_BUSINESS_TIME_RANGE(BAD_REQUEST, "영업시간이 허용된 범위를 벗어났습니다."),
 	CAFE_NOT_FOUND_DAY_OF_WEEK(INTERNAL_SERVER_ERROR, "현재 요일과 일치하는 요일을 찾을 수 없습니다."),
+	CAFE_SEARCH_INVALID_TIME_RANGE(BAD_REQUEST, "종료 시간이 오픈 시간보다 빠릅니다."),
 
 	STUDY_MEMBER_NOT_FOUND(NOT_FOUND, "없는 스터디멤버입니다."),
 

--- a/src/main/java/com/example/demo/util/DefaultTimeUtil.java
+++ b/src/main/java/com/example/demo/util/DefaultTimeUtil.java
@@ -5,8 +5,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -36,4 +34,15 @@ public class DefaultTimeUtil implements TimeUtil {
 	public LocalDateTime localDateTime(int year, int month, int dayOfMonth, int hour, int minute, int second) {
 		return LocalDateTime.of(year, month, dayOfMonth, hour, minute);
 	}
+
+	@Override
+	public LocalDateTime minLocalDateTime(LocalDateTime now) {
+		return now.withHour(0).withMinute(0).withSecond(0);
+	}
+
+	@Override
+	public LocalDateTime maxLocalDateTime(LocalDateTime now) {
+		return now.withHour(23).withMinute(59).withSecond(59);
+	}
+
 }

--- a/src/main/java/com/example/demo/util/TimeUtil.java
+++ b/src/main/java/com/example/demo/util/TimeUtil.java
@@ -15,4 +15,8 @@ public interface TimeUtil {
 	LocalTime localTime(int hour, int minute, int second);
 
 	LocalDateTime localDateTime(int year, int month, int dayOfMonth, int hour, int minute, int second);
+
+	LocalDateTime minLocalDateTime(LocalDateTime now);
+
+	LocalDateTime maxLocalDateTime(LocalDateTime now);
 }

--- a/src/test/java/com/example/demo/apidocs/CafeControllerApiTest.java
+++ b/src/test/java/com/example/demo/apidocs/CafeControllerApiTest.java
@@ -6,6 +6,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper;
 import com.example.demo.cafe.domain.CafeTagType;
@@ -13,6 +15,7 @@ import com.example.demo.cafe.infrastructure.CafeEntity;
 import com.example.demo.cafe.infrastructure.CafeTagEntity;
 import com.example.demo.config.ApiDocsTest;
 import com.example.demo.helper.CafeCafeTagSaveHelper;
+import com.example.demo.helper.CafeKeywordSaveHelper;
 import com.example.demo.helper.CafeSaveHelper;
 import com.example.demo.helper.CafeStudyCafeStudyTagSaveHelper;
 import com.example.demo.helper.CafeStudySaveHelper;
@@ -25,7 +28,7 @@ import com.example.demo.util.TimeUtil;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
-public class CafeApiTest extends ApiDocsTest {
+public class CafeControllerApiTest extends ApiDocsTest {
 
 	@Autowired
 	private CafeSaveHelper cafeSaveHelper;
@@ -33,6 +36,8 @@ public class CafeApiTest extends ApiDocsTest {
 	private CafeTagSaveHelper cafeTagSaveHelper;
 	@Autowired
 	private CafeCafeTagSaveHelper cafeCafeTagSaveHelper;
+	@Autowired
+	private CafeKeywordSaveHelper cafeKeywordSaveHelper;
 	@Autowired
 	private MenuSaveHelper menuSaveHelper;
 	@Autowired
@@ -45,6 +50,59 @@ public class CafeApiTest extends ApiDocsTest {
 	private CafeStudyCafeStudyTagSaveHelper cafeStudyCafeStudyTagSaveHelper;
 	@Autowired
 	private TimeUtil timeUtil;
+
+	@Test
+	void searchCafes() {
+		CafeTagEntity cafeTag1 = cafeTagSaveHelper.saveCafeTag(CafeTagType.WIFI);
+		CafeTagEntity cafeTag2 = cafeTagSaveHelper.saveCafeTag(CafeTagType.OUTLET);
+		CafeTagEntity cafeTag3 = cafeTagSaveHelper.saveCafeTag(CafeTagType.COMFORTABLE_SEATING);
+
+		CafeEntity cafe1 = cafeSaveHelper.saveCafeWith7daysFrom9To21();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe1, cafeTag1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe1, cafeTag2);
+		CafeEntity cafe2 = cafeSaveHelper.saveCafeWith24For7();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe2);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag2);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag3);
+
+		// note: String type이 아니면 오류 발생...
+		// LocalDateTime openingDateTime = timeUtil.localDateTime(2001, 1, 1, 10, 0, 0);
+		// LocalDateTime closingDateTime = timeUtil.localDateTime(2001, 1, 1, 23, 59, 59);
+
+		String openingDateTime = "2000-01-01T10:00:00";
+		String closingDateTime = "2000-01-01T20:00:00";
+
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("keyword", "강남");
+		params.add("openingDateTime", openingDateTime);
+		params.add("closingDateTime", closingDateTime);
+		params.add("cafeTags", CafeTagType.WIFI.toString());
+		params.add("cafeTags", CafeTagType.OUTLET.toString());
+		params.add("page", "0");
+		params.add("sizePerPage", "10");
+
+		RestAssured.given(spec).log().all()
+			.filter(RestAssuredRestDocumentationWrapper.document(
+					"카페 목록 조회 API",
+					requestParameters(
+						parameterWithName("keyword").description("검색어"),
+						parameterWithName("openingDateTime").description("필터링 오픈시간"),
+						parameterWithName("closingDateTime").description("필터링 마감시간"),
+						parameterWithName("cafeTags").description("카페 태그 리스트, 여러개의 카페 태그를 넣을 수 있다."),
+						parameterWithName("page").description("페이지 번호, 0부터 시작한다."),
+						parameterWithName("sizePerPage").description("한 페이지에 들어가는 컨텐츠 개수")
+					)
+				)
+			)
+			.contentType(ContentType.JSON)
+			.params(params)
+			.when()
+			.get("/cafes")
+			.then().log().all()
+			.statusCode(200);
+	}
 
 	@Test
 	@DisplayName("카페 상세정보 조회 API")
@@ -96,30 +154,6 @@ public class CafeApiTest extends ApiDocsTest {
 
 						fieldWithPath("menusInfo[].name").description("메뉴 이름"),
 						fieldWithPath("menusInfo[].price").description("메뉴 가격")
-
-						// fieldWithPath("openCafeStudiesInfo[].id").description("오픈된 카공 ID"),
-						// fieldWithPath("openCafeStudiesInfo[].name").description("오픈된 카공 이름"),
-						// fieldWithPath("openCafeStudiesInfo[].tags[]").description("오픈된 카공 태그 리스트"),
-						// fieldWithPath("openCafeStudiesInfo[].startDateTime").description("오픈된 카공 시작 시간"),
-						// fieldWithPath("openCafeStudiesInfo[].endDateTime").description("오픈된 카공 종료 시간"),
-						// fieldWithPath("openCafeStudiesInfo[].maximumParticipants").description("오픈된 카공 최대 참가자 수"),
-						// fieldWithPath("openCafeStudiesInfo[].currentParticipants").description("오픈된 카공 현재 참가자 수"),
-						// fieldWithPath("openCafeStudiesInfo[].views").description("오픈된 카공 조회수"),
-						// fieldWithPath("openCafeStudiesInfo[].memberComms").description("오픈된 카공 참여자 소통 여부"),
-						// fieldWithPath("openCafeStudiesInfo[].recruitmentStatus").description("오픈된 카공 현재 모집 여부"),
-						// fieldWithPath("openCafeStudiesInfo[].writer").description("오픈된 카공 작성자"),
-						//
-						// fieldWithPath("closeCafeStudiesInfo[].id").description("닫힌 카공 ID"),
-						// fieldWithPath("closeCafeStudiesInfo[].name").description("닫힌 카공 이름"),
-						// fieldWithPath("closeCafeStudiesInfo[].tags[]").description("닫힌 카공 태그 리스트"),
-						// fieldWithPath("closeCafeStudiesInfo[].startDateTime").description("닫힌 카공 시작 시간"),
-						// fieldWithPath("closeCafeStudiesInfo[].endDateTime").description("닫힌 카공 종료 시간"),
-						// fieldWithPath("closeCafeStudiesInfo[].maximumParticipants").description("닫힌 카공 최대 참가자 수"),
-						// fieldWithPath("closeCafeStudiesInfo[].currentParticipants").description("닫힌 카공 현재 참가자 수"),
-						// fieldWithPath("closeCafeStudiesInfo[].views").description("닫힌 카공 조회수"),
-						// fieldWithPath("closeCafeStudiesInfo[].memberComms").description("닫힌 카공 참여자 소통 여부"),
-						// fieldWithPath("closeCafeStudiesInfo[].recruitmentStatus").description("닫힌 카공 현재 모집 여부"),
-						// fieldWithPath("closeCafeStudiesInfo[].writer").description("닫힌 카공 작성자")
 					)
 				)
 			)

--- a/src/test/java/com/example/demo/config/FakeTimeUtil.java
+++ b/src/test/java/com/example/demo/config/FakeTimeUtil.java
@@ -38,4 +38,14 @@ public class FakeTimeUtil implements TimeUtil {
 	public LocalDateTime localDateTime(int year, int month, int dayOfMonth, int hour, int minute, int second) {
 		return LocalDateTime.of(year, month, dayOfMonth, hour, minute);
 	}
+
+	@Override
+	public LocalDateTime minLocalDateTime(LocalDateTime now) {
+		return now.withHour(0).withMinute(0).withSecond(0);
+	}
+
+	@Override
+	public LocalDateTime maxLocalDateTime(LocalDateTime now) {
+		return now.withHour(23).withMinute(59).withSecond(59);
+	}
 }

--- a/src/test/java/com/example/demo/repository/cafe/CafeQueryRepositoryTest.java
+++ b/src/test/java/com/example/demo/repository/cafe/CafeQueryRepositoryTest.java
@@ -1,0 +1,472 @@
+package com.example.demo.repository.cafe;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import com.example.demo.cafe.domain.CafeTagType;
+import com.example.demo.cafe.infrastructure.CafeEntity;
+import com.example.demo.cafe.infrastructure.CafeQueryRepository;
+import com.example.demo.cafe.infrastructure.CafeTagEntity;
+import com.example.demo.cafe.presentation.CafeSearchListRequest;
+import com.example.demo.config.FakeTimeUtil;
+import com.example.demo.config.JpaTest;
+import com.example.demo.helper.CafeCafeTagSaveHelper;
+import com.example.demo.helper.CafeKeywordSaveHelper;
+import com.example.demo.helper.CafeSaveHelper;
+import com.example.demo.helper.CafeStudySaveHelper;
+import com.example.demo.helper.CafeTagSaveHelper;
+import com.example.demo.helper.MemberSaveHelper;
+import com.example.demo.member.infrastructure.MemberEntity;
+import com.example.demo.trash.dto.SliceResponse;
+import com.example.demo.util.TimeUtil;
+
+@Import(CafeQueryRepository.class)
+public class CafeQueryRepositoryTest extends JpaTest {
+
+	@Autowired
+	private CafeQueryRepository sut;
+
+	@Autowired
+	private CafeStudySaveHelper cafeStudySaveHelper;
+	@Autowired
+	private CafeSaveHelper cafeSaveHelper;
+	@Autowired
+	private MemberSaveHelper memberSaveHelper;
+	@Autowired
+	private CafeKeywordSaveHelper cafeKeywordSaveHelper;
+	@Autowired
+	private CafeTagSaveHelper cafeTagSaveHelper;
+	@Autowired
+	private CafeCafeTagSaveHelper cafeCafeTagSaveHelper;
+	@Autowired
+	private TimeUtil timeUtil;
+
+	@ParameterizedTest
+	@MethodSource("provideKeywords1")
+	@DisplayName("검색어로 카페를 조회한다.")
+	void find_cafes_by_keyword(String keyword, int expected) {
+		// given
+		CafeEntity cafe1 = cafeSaveHelper.saveCafeWith7daysFrom9To21();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe1);
+		cafeKeywordSaveHelper.saveCafeKeyword("스타벅스 강남대로점", cafe1);
+		cafeKeywordSaveHelper.saveCafeKeyword("서울 강남구 강남대로 456 한석타워 2층 1-2호 (역삼동)", cafe1);
+
+		CafeEntity cafe2 = cafeSaveHelper.saveCafeWith24For7();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe2);
+		cafeKeywordSaveHelper.saveCafeKeyword("스타벅스 신논현역점", cafe2);
+		cafeKeywordSaveHelper.saveCafeKeyword("서울 서초구 강남대로 483 (반포동) 청호빌딩", cafe2);
+		cafeKeywordSaveHelper.saveCafeKeyword("카공하기 좋은 카페", cafe2);
+
+		LocalDateTime defaultOpeningDateTime = timeUtil.minLocalDateTime(timeUtil.now());
+		LocalDateTime defaultClosingDateTime = timeUtil.maxLocalDateTime(timeUtil.now());
+
+		// when
+		SliceResponse<CafeEntity> result = sut.findCafeByRegionAndKeyword(
+			createCafeSearchListRequest(
+				keyword, defaultOpeningDateTime, defaultClosingDateTime, null, 0, 10
+			));
+
+		//then
+		assertThat(result.getContent().size()).isEqualTo(expected);
+
+	}
+
+	private static Stream<Arguments> provideKeywords1() {
+		return Stream.of(
+			//Cafe1과 Cafe2 둘다 관련된 테스트
+			Arguments.of("강남", 2),
+			Arguments.of("강남 ", 2),
+			Arguments.of("스타벅스", 2),
+			Arguments.of("스타벅스 ", 2),
+
+			//Cafe1과 관련된 테스트
+			Arguments.of("스타벅스 강남대로", 1),
+			Arguments.of("스타벅스 강남대로점", 1),
+			Arguments.of("스타벅스강남대로점", 1),
+			Arguments.of("강남구", 1),
+
+			//Cafe2와 관련된 테스트
+			Arguments.of("신논현", 1),
+			Arguments.of("스타벅스 신논현역", 1),
+			Arguments.of("스타벅스 신논현역점", 1),
+			Arguments.of("스타벅스신논현역점", 1),
+			Arguments.of("반포동", 1),
+			Arguments.of("카공하기 좋은 카페", 1)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideTime1")
+	@DisplayName("특정 시간으로 필터링한 카페 목록을 조회한다.")
+	void find_cafes_by_time(
+		LocalDateTime openingDateTime, LocalDateTime closingDateTime, int expected
+	) {
+		// given
+		CafeEntity cafe1 = cafeSaveHelper.saveCafeWith7daysFrom9To21();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe1);
+
+		CafeEntity cafe2 = cafeSaveHelper.saveCafeWith24For7();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe2);
+
+		// when
+		SliceResponse<CafeEntity> result = sut.findCafeByRegionAndKeyword(
+			createCafeSearchListRequest(
+				"강남", openingDateTime, closingDateTime, null, 0, 10
+			));
+
+		//then
+		assertThat(result.getContent().size()).isEqualTo(expected);
+
+	}
+
+	private static Stream<Arguments> provideTime1() {
+		TimeUtil timeUtil = new FakeTimeUtil();
+
+		return Stream.of(
+			Arguments.of(
+				timeUtil.localDateTime(2000, 1, 1, 9, 0, 0),
+				timeUtil.localDateTime(2000, 1, 1, 21, 0, 0),
+				2
+			),
+			Arguments.of(
+				timeUtil.localDateTime(2000, 1, 1, 21, 1, 1),
+				timeUtil.localDateTime(2000, 1, 1, 23, 59, 59),
+				1
+			),
+			Arguments.of(
+				timeUtil.localDateTime(2000, 1, 1, 0, 0, 0),
+				timeUtil.localDateTime(2000, 1, 1, 23, 59, 59),
+				2
+			),
+			// 필터링 조건의 날짜가 다른 경우
+			Arguments.of(
+				timeUtil.localDateTime(2000, 1, 1, 9, 0, 0),
+				timeUtil.localDateTime(2000, 1, 2, 2, 0, 0),
+				2
+			)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideCafeTag")
+	@DisplayName("하나의 카페 태그로 필터링한 카페 목록을 조회한다.")
+	void find_cafes_by_cafe_tag(CafeTagType type, int expected) {
+		// given
+		CafeTagEntity cafeTag1 = cafeTagSaveHelper.saveCafeTag(CafeTagType.WIFI);
+		CafeTagEntity cafeTag2 = cafeTagSaveHelper.saveCafeTag(CafeTagType.OUTLET);
+
+		CafeEntity cafe1 = cafeSaveHelper.saveCafeWith7daysFrom9To21();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe1, cafeTag1);
+
+		CafeEntity cafe2 = cafeSaveHelper.saveCafeWith24For7();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe2);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag2);
+
+		LocalDateTime defaultOpeningDateTime = timeUtil.minLocalDateTime(timeUtil.now());
+		LocalDateTime defaultClosingDateTime = timeUtil.maxLocalDateTime(timeUtil.now());
+
+		// when
+		SliceResponse<CafeEntity> result = sut.findCafeByRegionAndKeyword(
+			createCafeSearchListRequest(
+				"강남", defaultOpeningDateTime, defaultClosingDateTime, List.of(type), 0, 10
+			));
+
+		//then
+		assertThat(result.getContent().size()).isEqualTo(expected);
+
+	}
+
+	private static Stream<Arguments> provideCafeTag() {
+		return Stream.of(
+			Arguments.of(CafeTagType.WIFI, 2),
+			Arguments.of(CafeTagType.OUTLET, 1),
+			Arguments.of(CafeTagType.COMFORTABLE_SEATING, 0)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideCafeTag2")
+	@DisplayName("여러개의 카페 태그로 필터링한 카페 목록을 조회한다.")
+	void find_cafes_by_cafe_tags(List<CafeTagType> types, int expected) {
+		// given
+		CafeTagEntity cafeTag1 = cafeTagSaveHelper.saveCafeTag(CafeTagType.WIFI);
+		CafeTagEntity cafeTag2 = cafeTagSaveHelper.saveCafeTag(CafeTagType.OUTLET);
+		CafeTagEntity cafeTag3 = cafeTagSaveHelper.saveCafeTag(CafeTagType.COMFORTABLE_SEATING);
+
+		CafeEntity cafe1 = cafeSaveHelper.saveCafeWith7daysFrom9To21();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe1, cafeTag1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe1, cafeTag2);
+
+		CafeEntity cafe2 = cafeSaveHelper.saveCafeWith24For7();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe2);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag2);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag3);
+
+		LocalDateTime defaultOpeningDateTime = timeUtil.minLocalDateTime(timeUtil.now());
+		LocalDateTime defaultClosingDateTime = timeUtil.maxLocalDateTime(timeUtil.now());
+
+		// when
+		SliceResponse<CafeEntity> result = sut.findCafeByRegionAndKeyword(
+			createCafeSearchListRequest(
+				"강남", defaultOpeningDateTime, defaultClosingDateTime, types, 0, 10
+			));
+
+		//then
+		assertThat(result.getContent().size()).isEqualTo(expected);
+
+	}
+
+	private static Stream<Arguments> provideCafeTag2() {
+		return Stream.of(
+			Arguments.of(List.of(CafeTagType.WIFI, CafeTagType.OUTLET), 2),
+			Arguments.of(List.of(CafeTagType.WIFI, CafeTagType.COMFORTABLE_SEATING), 1),
+			Arguments.of(List.of(CafeTagType.WIFI, CafeTagType.QUIET), 0)
+		);
+	}
+
+	@Test
+	@DisplayName("카페 목록 조회는 카공 개수가 많은 순으로 정렬한다.")
+	void show_available_cafe_first() throws Exception {
+		//given
+		CafeEntity cafe1 = cafeSaveHelper.saveCafeWith24For7();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe1);
+
+		CafeEntity cafe2 = cafeSaveHelper.saveCafeWith7daysFrom9To21();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe2);
+
+		CafeEntity cafe3 = cafeSaveHelper.saveCafeWith7daysFrom9To21();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe3);
+
+		MemberEntity member = memberSaveHelper.saveMember();
+
+		LocalDateTime startDateTime = timeUtil.localDateTime(2000, 1, 1, 9, 0, 0);
+
+		cafeStudySaveHelper.saveCafeStudy(cafe1, member, startDateTime.plusHours(8), startDateTime.plusHours(10));
+		Thread.sleep(1000);
+		cafeStudySaveHelper.saveCafeStudy(cafe1, member, startDateTime.plusHours(2), startDateTime.plusHours(4));
+		Thread.sleep(1000);
+		cafeStudySaveHelper.saveCafeStudy(cafe1, member, startDateTime.plusHours(5), startDateTime.plusHours(7));
+		Thread.sleep(1000);
+		cafeStudySaveHelper.saveCafeStudy(cafe2, member, startDateTime.plusHours(12), startDateTime.plusHours(14));
+
+		LocalDateTime defaultOpeningDateTime = timeUtil.minLocalDateTime(timeUtil.now());
+		LocalDateTime defaultClosingDateTime = timeUtil.maxLocalDateTime(timeUtil.now());
+
+		// when
+		SliceResponse<CafeEntity> result = sut.findCafeByRegionAndKeyword(
+			createCafeSearchListRequest(
+				"강남", defaultOpeningDateTime, defaultClosingDateTime, null, 0, 10
+			));
+
+		//then
+		List<CafeEntity> content = result.getContent();
+		assertThat(content)
+			.extracting(CafeEntity::getId)
+			.containsExactlyInAnyOrder(cafe1.getId(), cafe2.getId(), cafe3.getId());
+
+	}
+
+	@Test
+	@DisplayName("첫번째 페이지에 대한 카페 목록을 조회한다.")
+	void find_cafes_with_first_page() {
+		//given
+		for (int i = 0; i < 6; i++) {
+			CafeEntity cafeEntity = cafeSaveHelper.saveCafeWith24For7();
+			cafeKeywordSaveHelper.saveCafeKeyword("강남", cafeEntity);
+		}
+
+		LocalDateTime defaultOpeningDateTime = timeUtil.minLocalDateTime(timeUtil.now());
+		LocalDateTime defaultClosingDateTime = timeUtil.maxLocalDateTime(timeUtil.now());
+
+		//when
+		SliceResponse<CafeEntity> result = sut.findCafeByRegionAndKeyword(
+			createCafeSearchListRequest(
+				"강남", defaultOpeningDateTime, defaultClosingDateTime, null, 0, 5
+			));
+
+		//then
+		assertThat(result.getContent().size()).isEqualTo(5);
+		assertThat(result.isHasNext()).isTrue();
+	}
+
+	@Test
+	@DisplayName("두번째 페이지에 대한 카페 목록을 조회한다.")
+	void find_cafes_with_second_page() {
+		//given
+		for (int i = 0; i < 11; i++) {
+			CafeEntity cafeEntity = cafeSaveHelper.saveCafeWith24For7();
+			cafeKeywordSaveHelper.saveCafeKeyword("강남", cafeEntity);
+		}
+
+		LocalDateTime defaultOpeningDateTime = timeUtil.minLocalDateTime(timeUtil.now());
+		LocalDateTime defaultClosingDateTime = timeUtil.maxLocalDateTime(timeUtil.now());
+
+		//when
+		SliceResponse<CafeEntity> result = sut.findCafeByRegionAndKeyword(
+			createCafeSearchListRequest(
+				"강남", defaultOpeningDateTime, defaultClosingDateTime, null, 1, 5
+			));
+
+		//then
+		assertThat(result.getContent().size()).isEqualTo(5);
+		assertThat(result.isHasNext()).isTrue();
+	}
+
+	@Test
+	@DisplayName("마지막 페이지에 대한 카페 목록을 조회한다.")
+	void find_cafes_with_last_page() {
+		//given
+		for (int i = 0; i < 11; i++) {
+			CafeEntity cafeEntity = cafeSaveHelper.saveCafeWith24For7();
+			cafeKeywordSaveHelper.saveCafeKeyword("강남", cafeEntity);
+		}
+
+		LocalDateTime defaultOpeningDateTime = timeUtil.minLocalDateTime(timeUtil.now());
+		LocalDateTime defaultClosingDateTime = timeUtil.maxLocalDateTime(timeUtil.now());
+
+		//when
+		SliceResponse<CafeEntity> result = sut.findCafeByRegionAndKeyword(
+			createCafeSearchListRequest(
+				"강남", defaultOpeningDateTime, defaultClosingDateTime, null, 2, 5
+			));
+
+		//then
+		assertThat(result.getContent().size()).isEqualTo(1);
+		assertThat(result.isHasNext()).isFalse();
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideMultipleFiltering")
+	@DisplayName("다양한 필터링 조합으로 카페 목록을 조회한다.")
+	void find_cafes_by_many_different_filtering(
+		String keyword, LocalDateTime openingDateTime, LocalDateTime closingDateTime, List<CafeTagType> cafeTagTypes,
+		int expected
+	) {
+		//given
+		CafeTagEntity cafeTag1 = cafeTagSaveHelper.saveCafeTag(CafeTagType.WIFI);
+		CafeTagEntity cafeTag2 = cafeTagSaveHelper.saveCafeTag(CafeTagType.OUTLET);
+		CafeTagEntity cafeTag3 = cafeTagSaveHelper.saveCafeTag(CafeTagType.COMFORTABLE_SEATING);
+
+		CafeEntity cafe1 = cafeSaveHelper.saveCafeWith7daysFrom9To21();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe1);
+		cafeKeywordSaveHelper.saveCafeKeyword("스타벅스 강남대로점", cafe1);
+		cafeKeywordSaveHelper.saveCafeKeyword("서울 강남구 강남대로 456 한석타워 2층 1-2호 (역삼동)", cafe1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe1, cafeTag1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe1, cafeTag2);
+
+		CafeEntity cafe2 = cafeSaveHelper.saveCafeWith24For7();
+		cafeKeywordSaveHelper.saveCafeKeyword("강남", cafe2);
+		cafeKeywordSaveHelper.saveCafeKeyword("스타벅스 신논현역점", cafe2);
+		cafeKeywordSaveHelper.saveCafeKeyword("서울 서초구 강남대로 483 (반포동) 청호빌딩", cafe2);
+		cafeKeywordSaveHelper.saveCafeKeyword("카공하기 좋은 카페", cafe2);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag1);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe2, cafeTag3);
+
+		CafeEntity cafe3 = cafeSaveHelper.saveCafeWith24For7();
+		cafeKeywordSaveHelper.saveCafeKeyword("부산", cafe3);
+		cafeKeywordSaveHelper.saveCafeKeyword("스타벅스 해운대달맞이점", cafe3);
+		cafeKeywordSaveHelper.saveCafeKeyword("부산 해운대구 달맞이길 189 (중동)", cafe3);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe3, cafeTag2);
+		cafeCafeTagSaveHelper.saveCafeCafeTag(cafe3, cafeTag3);
+
+		//when
+		SliceResponse<CafeEntity> result = sut.findCafeByRegionAndKeyword(
+			createCafeSearchListRequest(
+				keyword, openingDateTime, closingDateTime, cafeTagTypes, 0, 10
+			));
+
+		// then
+		assertThat(result.getContent().size()).isEqualTo(expected);
+	}
+
+	private static Stream<Arguments> provideMultipleFiltering() {
+		/*
+		1번 카페 조회 필터링 조건
+		키워드: 스타벅스
+		오픈 시간: 9시
+		마감 시간: 21시
+		카페 태그: null
+
+		2번 카페 조회 필터링 조건
+		키워드: 강남
+		오픈 시간: 9시
+		마감 시간: 21시
+		카페 태그: WIFI
+
+		3번 카페 조회 필터링 조건
+		키워드: 스타벅스
+		오픈 시간: 00시
+		마감 시간: 23시 59분 59초
+		카페 태그: WIFI, COMFORTABLE_SEATING
+
+		4번 카페 조회 필터링 조건
+		키워드: 스타벅스
+		오픈 시간: 9시
+		마감 시간: 익일 2시
+		카페 태그: WIFI, OUTLET, COMFORTABLE_SEATING
+		 */
+
+		TimeUtil timeUtil = new FakeTimeUtil();
+
+		return Stream.of(
+			Arguments.of(
+				"스타벅스",
+				timeUtil.localDateTime(2000, 1, 1, 9, 0, 0),
+				timeUtil.localDateTime(2000, 1, 1, 21, 0, 0),
+				null,
+				3
+			),
+			Arguments.of(
+				"강남",
+				timeUtil.localDateTime(2000, 1, 1, 9, 0, 0),
+				timeUtil.localDateTime(2000, 1, 1, 21, 0, 0),
+				List.of(CafeTagType.WIFI),
+				2
+			),
+			Arguments.of(
+				"스타벅스",
+				timeUtil.localDateTime(2000, 1, 1, 9, 0, 0),
+				timeUtil.localDateTime(2000, 1, 1, 23, 59, 59),
+				List.of(CafeTagType.WIFI, CafeTagType.COMFORTABLE_SEATING),
+				1
+			),
+			Arguments.of(
+				"스타벅스",
+				timeUtil.localDateTime(2000, 1, 1, 9, 0, 0),
+				timeUtil.localDateTime(2000, 1, 2, 2, 0, 0),
+				List.of(CafeTagType.WIFI, CafeTagType.OUTLET, CafeTagType.COMFORTABLE_SEATING),
+				0
+			)
+		);
+
+	}
+
+	private CafeSearchListRequest createCafeSearchListRequest(
+		String keyword, LocalDateTime openingDateTime, LocalDateTime closingDateTime, List<CafeTagType> cafeTags,
+		int page, int sizePerPage
+	) {
+		return CafeSearchListRequest.builder()
+			.keyword(keyword)
+			.openingDateTime(openingDateTime)
+			.closingDateTime(closingDateTime)
+			.cafeTagTypes(cafeTags)
+			.page(page)
+			.sizePerPage(sizePerPage)
+			.build();
+	}
+}


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호

#76 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 키워드를 통해 카페 목록을 조회할 수 있다.
- [x] 태그를 통해 카페 목록을 조회할 수 있다.
- [x] 영업 시간을 통해 카페 목록을 조회할 수 있다.
- [x] 필터링 시간의 마감 시간이 오픈 시간보다 빠를 수 없다.

### 스크린샷 (선택)

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
1. CafeSearchListRequest 에서 오픈시간과 마감시간이 따로 입력되지 않았다면 00시, 24시로 설정해야 합니다.
    1. Service에서 null 값 판단 후 변환하고자 하였으나 dto의 값을 service단에서 변환하는 것 보다 dto 내부에서 변환하는게 좋을 것 같다고 생각함
    2. Request 내부에서 null 값을 갖는지 확인한 후 변환하는 로직을 사용하려고 했으나 dto 필드로 TimeUtil이 있는게 올바르지 않다고 생각이 듦
    그래서 최종적으로 service단에서 변환하고 있습니다.
    
    하지만 현재 코드의 문제점은 service단에서 오픈시간, 마감시간 둘 다 직접 메서드를 사용하여 변환해줘야 합니다. 이를 하나의 메서드로 묶긴 했지만 좋은 코드로 생각되진 않습니다….

2. 카페 목록은 카페에서 진행되는 카공의 수가 많은 순으로 정렬됩니다. 이를 위해 `List<CafeStudyEntity>` 를 CafeEntity의 컬럼으로 추가하였습니다.
